### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,24 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "indirect"
+
+  # Keep SHA-pinned GitHub Actions up to date. Dependabot rewrites the pinned
+  # SHA and the trailing "# vX.Y.Z" comment together, so pins never go stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "devops-thiago"
+    assignees:
+      - "devops-thiago"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, main ]
 
+# Least-privilege default for every job in this workflow.
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -15,54 +19,55 @@ jobs:
   test:
     name: Test and Analysis
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    
+        persist-credentials: false
+
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '17'
         distribution: 'temurin'
-    
+
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    
+
     - name: Cache SonarCloud packages
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
         restore-keys: ${{ runner.os }}-sonar
-    
+
     - name: Run tests and generate coverage
       run: mvn clean verify
-    
+
     - name: Run SonarCloud analysis
       if: env.SONAR_TOKEN != ''
       run: mvn sonar:sonar
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    
+
     - name: Upload coverage to Codecov
       if: env.CODECOV_TOKEN != ''
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./target/site/jacoco/jacoco.xml
+        files: ./target/site/jacoco/jacoco.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
-    
+
     - name: Archive test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: ci-results
@@ -77,28 +82,30 @@ jobs:
     name: Build and Package
     needs: test
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '17'
         distribution: 'temurin'
-    
+
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    
+
     - name: Build package
       run: mvn clean package -DskipTests
-    
+
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: jar-artifact
         path: target/*.jar

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ master, main ]
 
+# Least-privilege default for every job in this workflow.
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -12,52 +16,53 @@ env:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    
+        persist-credentials: false
+
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
       with:
         java-version: '17'
         distribution: 'temurin'
-    
+
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-    
+
     - name: Run tests
       run: mvn clean test
-    
+
     - name: Generate test coverage report
       run: mvn jacoco:report
-    
+
     - name: Run checkstyle
       run: mvn checkstyle:check
       continue-on-error: true
-    
+
     - name: Run PMD
       run: mvn pmd:check
       continue-on-error: true
-    
+
     - name: Run SpotBugs
       run: mvn spotbugs:check
       continue-on-error: true
-    
+
     - name: Check code formatting with Spotless
       run: mvn spotless:check
       continue-on-error: true
-    
+
     - name: Build package
       run: mvn clean package -DskipTests
-    
+
     - name: Cache SonarCloud packages
-      uses: actions/cache@v3
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
@@ -72,16 +77,16 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: env.CODECOV_TOKEN != ''
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./target/site/jacoco/jacoco.xml
+        files: ./target/site/jacoco/jacoco.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
-    
+
     - name: Archive test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: always()
       with:
         name: test-results


### PR DESCRIPTION
The repository now only permits official/verified actions and requires every action to be pinned to a full-length commit SHA. All 16 `uses:` entries referenced floating tags, so both workflows were being rejected.

- Pin every action to its release commit SHA, with a trailing version comment so the intended version stays readable:
    actions/checkout        v3 -> v7.0.1 (3d3c42e)
    actions/setup-java      v3 -> v5.6.0 (03ad4de)
    actions/cache           v3 -> v6.1.0 (55cc834)
    actions/upload-artifact v4 -> v7.0.1 (043fb46)
    codecov/codecov-action  v3 -> v7.0.0 (fb8b358)
- Rename the Codecov `file` input to `files`; `file` was removed in v4.
- Add `permissions: contents: read` to both workflows so jobs stop
  running with the default write-capable token.
- Add `persist-credentials: false` to checkout so the token is not left
  behind in .git/config. Nothing in either workflow pushes.
- Add the github-actions ecosystem to Dependabot, grouped and weekly, so
  the new pins get bumped instead of silently rotting.

Job graphs, step order and Maven commands are unchanged.